### PR TITLE
Add support for sticker, animated images and audio files

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ class App extends MatrixPuppetBridgeBase {
     this.thirdPartyClient.on('message', (data)=>{
       const { senderID, body, threadID, isGroup } = data;
       const isMe = senderID === this.thirdPartyClient.userId;
-      console.log("ISME?", isMe);
+      debug("ISME? " + isMe);
       this.threadInfo[threadID] = { isGroup };
       const payload = {
         roomId: threadID,

--- a/index.js
+++ b/index.js
@@ -52,6 +52,13 @@ class App extends MatrixPuppetBridgeBase {
             senderId: isMe? undefined : senderID,
             text: attachment.thumbnailUrl
           };
+        } else if (attachment.type === 'file') {
+          debug('Attachment is a file');
+          payload = {
+            roomId: threadID,
+            senderId: isMe? undefined : senderID,
+            text: attachment.name + ': ' + attachment.url
+          };
         } else {
           debug('Unknown attachment type %s', attachment.type);
         }

--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ class App extends MatrixPuppetBridgeBase {
           text: body
         };
         debug(payload);
+        return this.handleThirdPartyRoomMessage(payload);
       } else if (attachments.length >= 0) {
         debug('Message has an attachment');
         let attachment = attachments[0];
@@ -43,15 +44,23 @@ class App extends MatrixPuppetBridgeBase {
           payload = {
             roomId: threadID,
             senderId: isMe? undefined : senderID,
-            text: attachment.url
+            text: "sticker",
+            url: attachment.url,
+            h: attachment.heigh,
+            w: attachment.width
           };
+          return this.handleThirdPartyRoomImageMessage(payload);
         } else if (attachment.type === 'animated_image') {
           debug('Attachment is an animated image');
           payload = {
             roomId: threadID,
             senderId: isMe? undefined : senderID,
-            text: attachment.thumbnailUrl
+            text: attachment.name, 
+            url: attachment.previewUrl,
+            h: attachment.previewWidth,
+            w: attachment.previewHeight
           };
+          return this.handleThirdPartyRoomImageMessage(payload);
         } else if (attachment.type === 'file') {
           debug('Attachment is a file');
           payload = {
@@ -59,14 +68,13 @@ class App extends MatrixPuppetBridgeBase {
             senderId: isMe? undefined : senderID,
             text: attachment.name + ': ' + attachment.url
           };
+          return this.handleThirdPartyRoomMessage(payload);
         } else {
           debug('Unknown attachment type %s', attachment.type);
         }
       } else {
         debug('Unknown message');
       }
-
-      return this.handleThirdPartyRoomMessage(payload);
     });
     return this.thirdPartyClient.login();
   }

--- a/index.js
+++ b/index.js
@@ -20,7 +20,6 @@ class App extends MatrixPuppetBridgeBase {
     this.thirdPartyClient = new FacebookClient(this.config.facebook);
     this.thirdPartyClient.on('message', (data)=>{
       const { senderID, body, threadID, isGroup, attachments } = data;
-      debug(attachments);
       const isMe = senderID === this.thirdPartyClient.userId;
       debug("ISME? " + isMe);
       this.threadInfo[threadID] = { isGroup };

--- a/index.js
+++ b/index.js
@@ -46,7 +46,8 @@ class App extends MatrixPuppetBridgeBase {
             text: "sticker",
             url: attachment.url,
             h: attachment.heigh,
-            w: attachment.width
+            w: attachment.width,
+            mimetype: 'image/png'
           };
           return this.handleThirdPartyRoomImageMessage(payload);
         } else if (attachment.type === 'animated_image') {
@@ -57,7 +58,8 @@ class App extends MatrixPuppetBridgeBase {
             text: attachment.name, 
             url: attachment.previewUrl,
             h: attachment.previewWidth,
-            w: attachment.previewHeight
+            w: attachment.previewHeight,
+            mimetype: 'image/gif'
           };
           return this.handleThirdPartyRoomImageMessage(payload);
         } else if (attachment.type === 'photo') {

--- a/index.js
+++ b/index.js
@@ -61,6 +61,17 @@ class App extends MatrixPuppetBridgeBase {
             w: attachment.previewHeight
           };
           return this.handleThirdPartyRoomImageMessage(payload);
+        } else if (attachment.type === 'photo') {
+          debug('Attachment is a photo');
+          payload = {
+            roomId: threadID,
+            senderId: isMe? undefined : senderID,
+            text: attachment.filename,
+            url: attachment.largePreviewUrl,
+            h: attachment.largePreviewHeight,
+            w: attachment.largePreviewWidth
+          };
+          return this.handleThirdPartyRoomImageMessage(payload);
         } else if (attachment.type === 'file') {
           debug('Attachment is a file');
           payload = {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "bluebird": "^3.4.6",
     "debug": "^2.6.0",
     "facebook-chat-api": "^1.2.0",
-    "matrix-puppet-bridge": "^1.10.0"
+    "matrix-puppet-bridge": "^1.11.0"
   },
   "devDependencies": {
     "eslint": "^3.12.2"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "bluebird": "^3.4.6",
     "debug": "^2.6.0",
     "facebook-chat-api": "^1.2.0",
-    "matrix-puppet-bridge": "^1.5.0"
+    "matrix-puppet-bridge": "^1.10.0"
   },
   "devDependencies": {
     "eslint": "^3.12.2"


### PR DESCRIPTION
They are now forwarded from Facebook to Matrix.

The images are sent as `m.image` messages, the audio file is just a text message with the URL for now.