### PR TITLE
Register aliases #facebook_.*

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,6 +157,7 @@ new Cli({
       reg.setAppServiceToken(AppServiceRegistration.generateToken());
       reg.setSenderLocalpart("facebookbot");
       reg.addRegexPattern("users", "@facebook_.*", true);
+      reg.addRegexPattern("aliases", "#facebook_.*", true);
       callback(reg);
     }).catch(err=>{
       console.error(err.message);


### PR DESCRIPTION
This is necessary for the particular case when we talk with ourself (yes, facebook allows it). Because there is no `@facebook_*` users on this room, we need to register the alias to get the messages.

Thanks @daniel:dkess.me for finding this bug.