### PR TITLE
Temporarily removed the aliases from the generated registration file

### DIFF
--- a/index.js
+++ b/index.js
@@ -172,7 +172,8 @@ new Cli({
       reg.setAppServiceToken(AppServiceRegistration.generateToken());
       reg.setSenderLocalpart("facebookbot");
       reg.addRegexPattern("users", "@facebook_.*", true);
-      reg.addRegexPattern("aliases", "#facebook_.*", true);
+      // Below commented until https://github.com/matrix-hacks/matrix-puppet-bridge/issues/17 is fixed
+      //reg.addRegexPattern("aliases", "#facebook_.*", true);
       callback(reg);
     }).catch(err=>{
       console.error(err.message);


### PR DESCRIPTION
The cause of around 10 hours of brain scratching on my behalf, if there isn't already a #facebook_puppetStatusRoom before the bridge is enabled, one will not be created due to a [problem in matrix-puppet-bridge](https://github.com/matrix-hacks/matrix-puppet-bridge/issues/17). Removing the alias from the registration file allows the bridge to create the channel.