### PR TITLE
Remove facebook link tracker

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,7 +94,13 @@ class App extends MatrixPuppetBridgeBase {
             debug('Attachment is a facebook share');
             var url;
             if (attachment.facebookUrl.startsWith('http://') || attachment.facebookUrl.startsWith('https://')) {
-              url = attachment.facebookUrl;
+              const urlObject = new URL(attachment.facebookUrl);
+              if (urlObject.hostname == "l.facebook.com" && urlObject.pathname == "/l.php") {
+                // Remove facebook link tracker
+                url = urlObject.searchParams.get("u");
+              } else {
+                url = attachment.facebookUrl;
+              }
             } else {
               url = 'https://www.facebook.com' + attachment.facebookUrl;
             }


### PR DESCRIPTION
When facebook share send a link like `https://l.facebook.com/l.php?u=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DYPy2hytwDLM&h=AT1Bp91G7HBM6Ok33adCo8J0czmcrFTyfntPGoLkW7dXhOMi1fWVrgOL5tN24EvhvkPKvyCmbWI0Gy8Gs7W044t57sdAfgk1hv544qISz9asZS38Gp9LumPvtGlB57_KDm1XZKfXWJR_fQo&s=1`, replace it with the `u` url parameter value