### PR TITLE
Send facebook share when there is an URL in the message 

### DIFF
--- a/index.js
+++ b/index.js
@@ -187,7 +187,15 @@ class App extends MatrixPuppetBridgeBase {
     });
   }
   sendMessageAsPuppetToThirdPartyRoomWithId(id, text) {
-    return this.thirdPartyClient.sendMessage(id, text);
+    const url = text.match(/(https?:\/\/[^\s]+)/g);
+    if (url) {
+      return this.thirdPartyClient.sendMessage(id, {
+        body: text,
+        url: url[0],
+      });
+    } else {
+      return this.thirdPartyClient.sendMessage(id, text);
+    }
   }
   sendImageMessageAsPuppetToThirdPartyRoomWithId(id, data) {
     return this.thirdPartyClient.sendMessage(id, {


### PR DESCRIPTION
Currently when sending a message with a link inside it, facebook does not display a preview of the content. This PR sends a facebook share message when there is a http(s)://... url in the message.

The behaviour is identical to sending a message from facebook messenger:
![image](https://user-images.githubusercontent.com/999188/47506699-e7b2ed80-d870-11e8-80dc-eea9cf1fe673.png)

One little side effect is that the facebook bridge sends back the facebook share event to the room:
![image](https://user-images.githubusercontent.com/999188/47506974-88091200-d871-11e8-9f0e-7ecb89aac380.png)


