### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:8-alpine
+
+WORKDIR /usr/src/app
+
+ARG NODE_ENV
+ENV NODE_ENV $NODE_ENV
+
+COPY . .
+
+RUN npm install
+
+EXPOSE 8090
+CMD [ "npm", "start" ]


### PR DESCRIPTION
Adds a Dockerfile so it can be easily run through Docker. I've been using this internally for a while now.

Would it also be possible for the repository owner to set up [automated builds](https://docs.docker.com/docker-hub/builds/) as well? I can add documentation on how to use Docker to the README later depending on what the final image name is.