### PR TITLE
Send is_direct with the thirdPartyRoomData

### DIFF
--- a/index.js
+++ b/index.js
@@ -180,7 +180,7 @@ class App extends MatrixPuppetBridgeBase {
     return this.thirdPartyClient.getThreadInfo(threadId).then(data=>{
       let roomData = {
         name: data.name ? data.name : '',
-        topic: `Facebook ${label}`
+        topic: `Facebook ${label}`,
         // Add Matrix's is_direct to support Facebook's isGroup
         is_direct: !data.isGroup,
       };

--- a/index.js
+++ b/index.js
@@ -181,6 +181,8 @@ class App extends MatrixPuppetBridgeBase {
       let roomData = {
         name: data.name ? data.name : '',
         topic: `Facebook ${label}`
+        // Add Matrix's is_direct to support Facebook's isGroup
+        is_direct: !data.isGroup,
       };
       debug('room data', roomData);
       return roomData;


### PR DESCRIPTION
This requires matrix-hacks/matrix-puppet-bridge#52 to actually have any user-visible impact, however it shouldn't break anything if they don't get merged in at the same time.

This is intended to solve #4 