### PR TITLE
Have the Dockerfile install git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ENV NODE_ENV $NODE_ENV
 
 COPY . .
 
+RUN apk add git
 RUN npm install
 
 EXPOSE 8090


### PR DESCRIPTION
Currently when building the Docker image, it fails on `npm install` due to the lack of git. Installing git to the image before running `npm install` fixes this issue, resulting in a successful build.