### PR TITLE
[WIP] Start conversations with Facebook users

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,7 +161,6 @@ class App extends MatrixPuppetBridgeBase {
 
         const botIntent = this.getIntentFromApplicationServerBot();
         const botClient = botIntent.getClient();
-        debug("BOT", botClient.getUserId());
 
         for (const friend of friends) {
           // TODO bug with maximum listeners on event emitter, use the following
@@ -204,7 +203,7 @@ class App extends MatrixPuppetBridgeBase {
           debug(`User client started for ${friend.fullName}`);
         }
 
-      return this.joinThirdPartyUsersToStatusRoom(thirdPartyUsers);
+        debug("Contact list synced");
     });
 
     return this.thirdPartyClient.login();

--- a/index.js
+++ b/index.js
@@ -167,9 +167,9 @@ class App extends MatrixPuppetBridgeBase {
         for (const friend of friends) {
           // to test with a single facebook user
           //
-          if (friend.fullName !== "Yodan Theburgimastr") {
-            continue; // DEBUG
-          }
+          // if (friend.fullName !== "Yodan Theburgimastr") {
+          //   continue; // DEBUG
+          // }
 
           debug(`Getting user client for ${friend.fullName} (ID: ${friend.userID})`)
 


### PR DESCRIPTION
So this is my first version of the functionality to start conversations with facebook users (See https://github.com/matrix-hacks/matrix-puppet-facebook/issues/2).

What is works?
* Everything that already worked
* Avatars will now show up for facebook users
* When matrix-puppet-facebook is working, the fb users are listed as online.
* By starting a direct start with a facebook user listed in the status room, a conversation can be initiated without having to use facebook or messenger (so matrix will start the conversation).

What doesn't work?
*  Everything else. This code should thoroughly be tested. For example, what happens if the direct chat was already initiated (by the puppet, or by fb)? Will join or crash? What happens if everybody leaves #facebook_123456789@matrix.org (the alias still exists, can we reuse it)? etc. etc. etc.
* The code is very probably shit. I know almost nothing about JS or Node, so I had to dive in and learn it all. The various libraries matrix-sdk-js, matrix-appservice-bridge, matrix-puppet-bridge, and matrix-puppet-facebook are very confusing for newbies; which library does what? Probably some stuff I did here is already available as functions somewhere or I forgot to set some settings.

Although it is WIP (it is not in a merge state yet), it is a start and proofs this is possible. Right know, I need people to try and test it, and more experienced developers home in the matrix bridge matters to look at the code and how it can be improved.

@martijn:martijn.freeddns.org