### PR TITLE
Update base Node.js image in Dockerfile to version 10.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8-alpine
+FROM node:10-alpine
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
Following the installation and configuration guide in README, after Docker container is built and run, `docker logs` points out that JavaSript's SyntaxError is raised during the execution several times, each with the same output:
```
> DEBUG=matrix-puppet:* node index.js

/usr/src/app/node_modules/matrix-puppet-bridge/src/base.js:692
    } catch {
            ^

SyntaxError: Unexpected token {
```

This is due to use of optional catch binding, which is supported only in Node 10 and newer (see: #https://github.com/microsoft/types-publisher/pull/609). The base Node.js image used in this project is 8 though, which apparently doesn't support such syntax.

My solution to solve this problem is just to simply update Node.js image to minimal version that supports optional catch binding.
