### PR TITLE
Add video support from facebook to matrix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV NODE_ENV $NODE_ENV
 
 COPY . .
 
-RUN apk add git
+RUN apk add git ffmpeg
 RUN npm install
 
 EXPOSE 8090

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ To use the bridge, just wait until you receive a message from another facebook u
 
 - node.js: [nodejs.org: Installing Node.js via package manager](https://nodejs.org/en/download/package-manager/)
 - git
+- ffmpeg (optionnal: if not installed videos will only be shown as regular files on matrix client => no video preview)
 
 ## installation
 

--- a/index.js
+++ b/index.js
@@ -84,6 +84,16 @@ class App extends MatrixPuppetBridgeBase {
               w: attachment.largePreviewWidth || attachment.previewWidth
             };
             this.handleThirdPartyRoomImageMessage(payload);
+          } else if (attachment.type === 'video') {
+            debug('Attachment is a video');
+            payload = {
+              roomId: threadID,
+              senderId: isMe? undefined : senderID,
+              text: attachment.filename,
+              url: attachment.url,
+              mimetype: 'video/mpeg'
+            };
+            this.handleThirdPartyRoomMessageWithAttachment(payload);
           } else if (attachment.type === 'file') {
             debug('Attachment is a file');
             payload = {


### PR DESCRIPTION
## Current `master` behavior
- When a video is sent from Facebook, nothing received on matrix client
- [Debug log](https://github.com/matrix-hacks/matrix-puppet-facebook/blob/cb5a0627537925f2c1e89293bd23984e80bbf7d3/index.js#L146): `matrix-puppet:facebook Unknown attachment type video`

## Current branch behavior
- When a video is sent from Facebook, video is received on matrix client
  - is viewable (if `ffmpeg` is installed in bridge's environment)
  - and downloadable

## What changed?
- Recognized video attachment from Facebook, set its metadata then send it to matrix server
- Added `ffmpeg` dependency in `Dockerfile` and `README.md`

### What happens when `ffmepg` is not installed in bridge's environment?
- [Warning log](https://github.com/matrix-hacks/matrix-puppet-bridge/blob/186331f118c7c65e5617bdfa99f17e665935c3ef/src/base.js#L854): `matrix-puppet:Base:handleThirdPartyRoomMessageWithAttachment:info Couldn't get video dimensions. Is ffmpeg installed?`
- On matrix client the video only appears as a downloadable file: no preview shown ([source](https://github.com/matrix-hacks/matrix-puppet-bridge/blob/186331f118c7c65e5617bdfa99f17e665935c3ef/src/base.js#L850))