### PR TITLE
Add audio clip support from facebook to matrix

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,6 +94,16 @@ class App extends MatrixPuppetBridgeBase {
               mimetype: 'video/mpeg'
             };
             this.handleThirdPartyRoomMessageWithAttachment(payload);
+          } else if (attachment.type === 'audio') {
+            debug('Attachment is an audio clip');
+            payload = {
+              roomId: threadID,
+              senderId: isMe? undefined : senderID,
+              text: attachment.filename,
+              url: attachment.url,
+              mimetype: 'audio/mpeg'
+            };
+            this.handleThirdPartyRoomMessageWithAttachment(payload);
           } else if (attachment.type === 'file') {
             debug('Attachment is a file');
             payload = {


### PR DESCRIPTION
## Current `master` behavior
- When an audio clip is sent from Facebook, nothing is received on matrix client
- [Debug log](https://github.com/matrix-hacks/matrix-puppet-facebook/blob/cb5a0627537925f2c1e89293bd23984e80bbf7d3/index.js#L146): `matrix-puppet:facebook Unknown attachment type audio`

## Current branch behavior
- When an audio clip is sent from Facebook, audio received on matrix client
  - is listenable
  - and downloadable

## What changed?
- Recognized audio clip attachment from Facebook, set its metadata then send it to matrix server