### PR TITLE
Fix gif preview size from facebook to matrix

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,8 +68,8 @@ class App extends MatrixPuppetBridgeBase {
               senderId: isMe? undefined : senderID,
               text: attachment.filename,
               url: attachment.previewUrl,
-              h: attachment.previewWidth,
-              w: attachment.previewHeight,
+              w: attachment.previewWidth,
+              h: attachment.previewHeight,
               mimetype: 'image/gif'
             };
             this.handleThirdPartyRoomImageMessage(payload);


### PR DESCRIPTION
## Current `master` behavior
- When a gif is sent from Facebook, the image is displayed distorted on matrix client

## Current branch behavior
- When a gif is sent from Facebook, the image is displayed properly on matrix client

## What changed?
- Forwarded gif size was wrong, width was bound to height and vice-versa
- Width is now bound to width and height to height